### PR TITLE
支持在flow配置文件里查看文档注释，优化文件图标搜索，增加缓存

### DIFF
--- a/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileChangeListener.java
+++ b/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileChangeListener.java
@@ -1,0 +1,59 @@
+package top.xystudio.plugin.idea.liteflowx.system.provider;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiTreeChangeAdapter;
+import com.intellij.psi.PsiTreeChangeEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class JavaFileChangeListener extends PsiTreeChangeAdapter {
+
+    private final Project project;
+
+    public JavaFileChangeListener(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void beforeChildAddition(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    @Override
+    public void beforeChildRemoval(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    @Override
+    public void childRemoved(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    @Override
+    public void childReplaced(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    @Override
+    public void childAdded(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    @Override
+    public void childrenChanged(@NotNull PsiTreeChangeEvent event) {
+        handleEvent(event);
+    }
+
+    private void handleEvent(@NotNull PsiTreeChangeEvent event) {
+        PsiFile file = event.getFile();
+        if (file instanceof PsiJavaFile) {
+            PsiJavaFile javaFile = (PsiJavaFile) file;
+            for (PsiClass psiClass : javaFile.getClasses()) {
+                JavaFileIconCache.clearCache(project, psiClass);
+            }
+        }
+    }
+
+}

--- a/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileIconCache.java
+++ b/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileIconCache.java
@@ -10,32 +10,26 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author hongzhida
  * @date 2024-08-16
  */
 public class JavaFileIconCache {
-
-    private static CachedValue<Map<PsiClass, Icon>> cache;
+    private static final Map<Project, CachedValue<Map<PsiClass, Icon>>> projectCache = new ConcurrentHashMap<>();
 
     public static CachedValue<Map<PsiClass, Icon>> getCache(@NotNull Project project) {
-        if(cache == null) {
-            cache = CachedValuesManager.getManager(project).createCachedValue(() -> {
-                // Create and return the initial cache value
-                return CachedValueProvider.Result.create(new HashMap<>(), PsiModificationTracker.NEVER_CHANGED);
-            });
-        }
-        return cache;
+        return projectCache.computeIfAbsent(project, p-> CachedValuesManager.getManager(project).createCachedValue(() -> {
+            // Create and return the initial cache value
+            return CachedValueProvider.Result.create(new HashMap<>(), PsiModificationTracker.NEVER_CHANGED);
+        }));
     }
 
     public static void clearCache(Project project, PsiClass psiClass) {
-        if(cache != null) {
-            Map<PsiClass, Icon> map = getCache(project).getValue();
-            map.remove(psiClass);
-        };
+        Map<PsiClass, Icon> map = getCache(project).getValue();
+        map.remove(psiClass);
     }
 
     public static void updateCache(@NotNull Project project, PsiClass psiClass, Icon value) {

--- a/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileIconCache.java
+++ b/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/JavaFileIconCache.java
@@ -1,0 +1,52 @@
+package top.xystudio.plugin.idea.liteflowx.system.provider;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.util.CachedValue;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
+import com.intellij.psi.util.PsiModificationTracker;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author hongzhida
+ * @date 2024-08-16
+ */
+public class JavaFileIconCache {
+
+    private static CachedValue<Map<PsiClass, Icon>> cache;
+
+    public static CachedValue<Map<PsiClass, Icon>> getCache(@NotNull Project project) {
+        if(cache == null) {
+            cache = CachedValuesManager.getManager(project).createCachedValue(() -> {
+                // Create and return the initial cache value
+                return CachedValueProvider.Result.create(new HashMap<>(), PsiModificationTracker.NEVER_CHANGED);
+            });
+        }
+        return cache;
+    }
+
+    public static void clearCache(Project project, PsiClass psiClass) {
+        if(cache != null) {
+            Map<PsiClass, Icon> map = getCache(project).getValue();
+            map.remove(psiClass);
+        };
+    }
+
+    public static void updateCache(@NotNull Project project, PsiClass psiClass, Icon value) {
+        CachedValue<Map<PsiClass, Icon>> cache = getCache(project);
+        Map<PsiClass, Icon> map = cache.getValue();
+        map.put(psiClass, value);
+    }
+
+    public static Icon getFromCache(@NotNull Project project, PsiClass psiClass) {
+        Map<PsiClass, Icon> map = getCache(project).getValue();
+        return map.get(psiClass);
+    }
+
+}

--- a/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/LiteflowDocumentationProvider.java
+++ b/src/main/java/top/xystudio/plugin/idea/liteflowx/system/provider/LiteflowDocumentationProvider.java
@@ -1,0 +1,100 @@
+package top.xystudio.plugin.idea.liteflowx.system.provider;
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiDocCommentBase;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaDocumentedElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import top.xystudio.plugin.idea.liteflowx.functionImpl.findComponentsImpl;
+import top.xystudio.plugin.idea.liteflowx.system.language.psi.LiteFlowTypes;
+import top.xystudio.plugin.idea.liteflowx.util.LiteFlowUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * @author hongzhida
+ * @date 2024-08-03
+ */
+public class LiteflowDocumentationProvider extends AbstractDocumentationProvider {
+    @Override
+    public @Nullable String getQuickNavigateInfo(PsiElement element, PsiElement originalElement) {
+        return super.getQuickNavigateInfo(element, originalElement);
+    }
+
+    @Override
+    public @Nullable List<String> getUrlFor(PsiElement element, PsiElement originalElement) {
+        return super.getUrlFor(element, originalElement);
+    }
+
+    @Override
+    public @Nullable String generateHoverDoc(@NotNull PsiElement element, @Nullable PsiElement originalElement) {
+        return super.generateHoverDoc(element, originalElement);
+    }
+
+    @Override
+    public @Nullable @NlsSafe String generateRenderedDoc(@NotNull PsiDocCommentBase comment) {
+        return super.generateRenderedDoc(comment);
+    }
+
+    @Override
+    public void collectDocComments(@NotNull PsiFile file, @NotNull Consumer<? super @NotNull PsiDocCommentBase> sink) {
+        super.collectDocComments(file, sink);
+    }
+
+    @Override
+    public @Nullable PsiDocCommentBase findDocComment(@NotNull PsiFile file, @NotNull TextRange range) {
+        return super.findDocComment(file, range);
+    }
+
+    @Override
+    public @Nullable PsiElement getDocumentationElementForLookupItem(PsiManager psiManager, Object object, PsiElement element) {
+        return super.getDocumentationElementForLookupItem(psiManager, object, element);
+    }
+
+    @Override
+    public @Nullable PsiElement getDocumentationElementForLink(PsiManager psiManager, String link, PsiElement context) {
+        return super.getDocumentationElementForLink(psiManager, link, context);
+    }
+
+    @Override
+    public @Nullable PsiElement getCustomDocumentationElement(@NotNull Editor editor, @NotNull PsiFile file, @Nullable PsiElement contextElement, int targetOffset) {
+        if (contextElement != null && ((LeafPsiElement) contextElement).getElementType() == LiteFlowTypes.LITEFLOW_IDENTIFIER) {
+            return getJavaMethodFromLiteFlowElement(contextElement);
+        }
+        return super.getCustomDocumentationElement(editor, file, contextElement, targetOffset);
+    }
+
+    @Override
+    public @Nullable @NlsSafe String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+        if (element instanceof PsiMethod) {
+            PsiMethod method = (PsiMethod) element;
+            return getMethodDocumentation(method);
+        }
+        return null;
+    }
+
+    private PsiElement getJavaMethodFromLiteFlowElement(PsiElement element) {
+        String value = element.getText();
+        Optional<? extends PsiElement> psiElement = LiteFlowUtils.findTargetByName(element.getProject(), value, new findComponentsImpl());
+        // 返回对应的PsiMethod对象
+        return psiElement.orElse(null);
+    }
+
+    private String getMethodDocumentation(PsiMethod method) {
+        PsiJavaDocumentedElement docElement = (PsiJavaDocumentedElement) method;
+        if (docElement.getDocComment() != null) {
+            return docElement.getDocComment().getText();
+        }
+        return "No documentation available";
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -93,6 +93,9 @@
         <completion.contributor
                 language="LiteFlow"
                 implementationClass="top.xystudio.plugin.idea.liteflowx.system.language.completion.ElVariableRefCompletionContributor"/>
+        <lang.documentationProvider
+                language="LiteFlow"
+                implementationClass="top.xystudio.plugin.idea.liteflowx.system.provider.LiteflowDocumentationProvider"/>
 
         <!-- LiteFlow语法颜色设置页面 -->
         <colorSettingsPage
@@ -102,6 +105,7 @@
         <annotator
                 language="XML"
                 implementationClass="top.xystudio.plugin.idea.liteflowx.system.language.annotator.XmlChainAnnotator"/>
+
 
         <projectService id="liteflowx.JavaService" serviceImplementation="top.xystudio.plugin.idea.liteflowx.service.JavaService"/>
         <projectService id="liteflowx.LiteFlowService" serviceImplementation="top.xystudio.plugin.idea.liteflowx.service.LiteFlowService"/>
@@ -125,11 +129,12 @@
         <!-- 文件图标提供 -->
         <iconProvider id="liteflowx.FileIconProvider"
                       implementation="top.xystudio.plugin.idea.liteflowx.system.provider.FileIconProvider"/>
-
+        <psi.treeChangeListener implementation="top.xystudio.plugin.idea.liteflowx.system.provider.JavaFileChangeListener"/>
         <!-- 结构工具窗口 -->
         <toolWindow id="LiteFlowTool" icon="LiteFlowIcons.TOOL_WINDOW_ICON" anchor="right" order="last" canCloseContents="false"
                 factoryClass="top.xystudio.plugin.idea.liteflowx.system.toolWindow.LiteFlowToolWindowFactory"/>
-        
+
+
     </extensions>
 
     <actions>


### PR DESCRIPTION
支持在配置文件里查看文档注释
优化文件图标搜索，增加缓存，防止重复计算导致的卡顿，在2024.2版本，该问题会导致大类的方法搜索(cmd+F12)非常缓慢需要5-6秒，package重构需要10多秒才能在文件树上体现。
经测试。对图标判断做了缓存之后就不会有这个问题了。